### PR TITLE
Fix arguments of onRequestPermissionsResult method of RequestPermissionsResultListener interface

### DIFF
--- a/android/src/main/kotlin/com/tfliteflutter/tflite_flutter_helper/TfliteFlutterHelperPlugin.kt
+++ b/android/src/main/kotlin/com/tfliteflutter/tflite_flutter_helper/TfliteFlutterHelperPlugin.kt
@@ -140,14 +140,14 @@ class TfliteFlutterHelperPlugin : FlutterPlugin,
 		}
 	}
 
-	override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>?,
-											grantResults: IntArray?): Boolean {
+	override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>,
+											grantResults: IntArray): Boolean {
 		when (requestCode) {
 			AUDIO_RECORD_PERMISSION_CODE -> {
-				if (grantResults != null) {
-					permissionToRecordAudio = grantResults.isNotEmpty() &&
-							grantResults[0] == PackageManager.PERMISSION_GRANTED
-				}
+
+				permissionToRecordAudio = grantResults.isNotEmpty() &&
+						grantResults[0] == PackageManager.PERMISSION_GRANTED
+
 				completeInitializeRecorder()
 				return true
 			}


### PR DESCRIPTION
[io.flutter.plugin.common.PluginRegistry.RequestPermissionsResultListener](https://api.flutter.dev/javadoc/io/flutter/plugin/common/PluginRegistry.RequestPermissionsResultListener.html#onRequestPermissionsResult(int,java.lang.String%5B%5D,int%5B%5D)) interface has `onRequestPermissionsResult` method.

`onRequestPermissionsResult`'s second and third arguments was nullable field in original source.

According to io.flutter.plugin.common.PluginRegistry.RequestPermissionsResultListener](https://api.flutter.dev/javadoc/io/flutter/plugin/common/PluginRegistry.RequestPermissionsResultListener.html#onRequestPermissionsResult(int,java.lang.String%5B%5D,int%5B%5D)), second and third arguments are not nullable. 